### PR TITLE
Temporarily redirect to drkristof.com

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "redirects": [
+    {
+      "source": "/(.*)",
+      "destination": "https://drkristof.com/en",
+      "permanent": false
+    }
+  ]
+}


### PR DESCRIPTION
Temporarily redirect every route to https://drkristof.com/en using a 307 redirect. This can be removed later without browsers treating the move as permanent.