### PR TITLE
Use canonical redirect target

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "redirects": [
     {
       "source": "/(.*)",
-      "destination": "https://drkristof.com/en",
+      "destination": "https://www.drkristof.com/en",
       "permanent": false
     }
   ]


### PR DESCRIPTION
Point the temporary redirect directly to https://www.drkristof.com/en, avoiding an extra hop through the non-www domain.