### PR TITLE
Redirect to language-aware root

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "redirects": [
     {
       "source": "/(.*)",
-      "destination": "https://www.drkristof.com/en",
+      "destination": "https://www.drkristof.com",
       "permanent": false
     }
   ]


### PR DESCRIPTION
Redirect to https://www.drkristof.com and let the main site choose Russian or English from the saved preference or browser language. The language switch remains available.